### PR TITLE
[BE-08] 엔티티 및 레포지토리 생성

### DIFF
--- a/src/main/java/com/kakao/borrowme/BorrowmeApplication.java
+++ b/src/main/java/com/kakao/borrowme/BorrowmeApplication.java
@@ -2,7 +2,9 @@ package com.kakao.borrowme;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BorrowmeApplication {
 

--- a/src/main/java/com/kakao/borrowme/category/Category.java
+++ b/src/main/java/com/kakao/borrowme/category/Category.java
@@ -1,0 +1,4 @@
+package com.kakao.borrowme.category;
+
+public class Category {
+}

--- a/src/main/java/com/kakao/borrowme/category/Category.java
+++ b/src/main/java/com/kakao/borrowme/category/Category.java
@@ -1,4 +1,30 @@
 package com.kakao.borrowme.category;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "category_tb")
 public class Category {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_pk")
+    private Long id;
+
+    @NotNull
+    @Column(length = 45)
+    private String name;
+
+    @Builder
+    public Category(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
 }

--- a/src/main/java/com/kakao/borrowme/category/CategoryJPARepository.java
+++ b/src/main/java/com/kakao/borrowme/category/CategoryJPARepository.java
@@ -1,0 +1,6 @@
+package com.kakao.borrowme.category;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryJPARepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/kakao/borrowme/coin/Coin.java
+++ b/src/main/java/com/kakao/borrowme/coin/Coin.java
@@ -1,0 +1,4 @@
+package com.kakao.borrowme.coin;
+
+public class Coin {
+}

--- a/src/main/java/com/kakao/borrowme/coin/Coin.java
+++ b/src/main/java/com/kakao/borrowme/coin/Coin.java
@@ -1,4 +1,37 @@
 package com.kakao.borrowme.coin;
 
+import com.kakao.borrowme.user.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "coin_tb")
 public class Coin {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "coin_pk")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_pk")
+    private User user;
+
+    @NotNull
+    @ColumnDefault("0L")
+    private Long piece = 0L;
+
+    @Builder
+    public Coin(Long id, User user, Long piece) {
+        this.id = id;
+        this.user = user;
+        this.piece = piece;
+    }
 }

--- a/src/main/java/com/kakao/borrowme/coin/CoinJPARepository.java
+++ b/src/main/java/com/kakao/borrowme/coin/CoinJPARepository.java
@@ -1,0 +1,6 @@
+package com.kakao.borrowme.coin;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoinJPARepository extends JpaRepository<Coin, Long> {
+}

--- a/src/main/java/com/kakao/borrowme/coin/log/CoinLog.java
+++ b/src/main/java/com/kakao/borrowme/coin/log/CoinLog.java
@@ -1,4 +1,9 @@
 package com.kakao.borrowme.coin.log;
 
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+
+@EntityListeners(AuditingEntityListener.class)
 public class CoinLog {
 }

--- a/src/main/java/com/kakao/borrowme/coin/log/CoinLog.java
+++ b/src/main/java/com/kakao/borrowme/coin/log/CoinLog.java
@@ -1,9 +1,49 @@
 package com.kakao.borrowme.coin.log;
 
+import com.kakao.borrowme.coin.Coin;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.EntityListeners;
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
+@Entity
+@Table(name = "coin_log_tb")
 public class CoinLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "coin_log_pk")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coin_pk")
+    private Coin coin;
+
+    @NotNull
+    private Long piece;
+
+    @NotNull
+    @Column(length = 45)
+    private String coinType;
+
+    @NotNull
+    @CreatedDate
+    private LocalDateTime createAt;
+
+    @Builder
+    public CoinLog(Long id, Coin coin, Long piece, String coinType, LocalDateTime createAt) {
+        this.id = id;
+        this.coin = coin;
+        this.piece = piece;
+        this.coinType = coinType;
+        this.createAt = createAt;
+    }
 }

--- a/src/main/java/com/kakao/borrowme/coin/log/CoinLog.java
+++ b/src/main/java/com/kakao/borrowme/coin/log/CoinLog.java
@@ -1,0 +1,4 @@
+package com.kakao.borrowme.coin.log;
+
+public class CoinLog {
+}

--- a/src/main/java/com/kakao/borrowme/coin/log/CoinLogJPARepository.java
+++ b/src/main/java/com/kakao/borrowme/coin/log/CoinLogJPARepository.java
@@ -1,0 +1,6 @@
+package com.kakao.borrowme.coin.log;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoinLogJPARepository extends JpaRepository<CoinLog, Long> {
+}

--- a/src/main/java/com/kakao/borrowme/company/Company.java
+++ b/src/main/java/com/kakao/borrowme/company/Company.java
@@ -1,4 +1,34 @@
 package com.kakao.borrowme.company;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "company_tb")
 public class Company {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "company_pk")
+    private Long id;
+
+    @NotNull
+    @Column(length = 45)
+    private String name;
+
+    @Column(length = 200)
+    private String companyImagePath;
+
+    @Builder
+    public Company(Long id, String name, String companyImagePath) {
+        this.id = id;
+        this.name = name;
+        this.companyImagePath = companyImagePath;
+    }
 }

--- a/src/main/java/com/kakao/borrowme/company/Company.java
+++ b/src/main/java/com/kakao/borrowme/company/Company.java
@@ -1,0 +1,4 @@
+package com.kakao.borrowme.company;
+
+public class Company {
+}

--- a/src/main/java/com/kakao/borrowme/company/CompanyJPARepository.java
+++ b/src/main/java/com/kakao/borrowme/company/CompanyJPARepository.java
@@ -1,0 +1,6 @@
+package com.kakao.borrowme.company;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CompanyJPARepository extends JpaRepository<Company, Long> {
+}

--- a/src/main/java/com/kakao/borrowme/location/Location.java
+++ b/src/main/java/com/kakao/borrowme/location/Location.java
@@ -1,0 +1,4 @@
+package com.kakao.borrowme.location;
+
+public class Location {
+}

--- a/src/main/java/com/kakao/borrowme/location/Location.java
+++ b/src/main/java/com/kakao/borrowme/location/Location.java
@@ -1,4 +1,45 @@
 package com.kakao.borrowme.location;
 
+import com.kakao.borrowme.university.University;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "location_tb")
 public class Location {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "location_pk")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "university_pk")
+    private University university;
+
+    @NotNull
+    private BigDecimal latitude;
+
+    @NotNull
+    private BigDecimal longitude;
+
+    @NotNull
+    @Column(length = 45)
+    private String name;
+
+    @Builder
+    public Location(Long id, University university, BigDecimal latitude, BigDecimal longitude, String name) {
+        this.id = id;
+        this.university = university;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.name = name;
+    }
 }

--- a/src/main/java/com/kakao/borrowme/location/LocationJPARepository.java
+++ b/src/main/java/com/kakao/borrowme/location/LocationJPARepository.java
@@ -1,0 +1,6 @@
+package com.kakao.borrowme.location;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LocationJPARepository extends JpaRepository<Location, Long> {
+}

--- a/src/main/java/com/kakao/borrowme/product/Product.java
+++ b/src/main/java/com/kakao/borrowme/product/Product.java
@@ -1,0 +1,4 @@
+package com.kakao.borrowme.product;
+
+public class Product {
+}

--- a/src/main/java/com/kakao/borrowme/product/Product.java
+++ b/src/main/java/com/kakao/borrowme/product/Product.java
@@ -1,4 +1,9 @@
 package com.kakao.borrowme.product;
 
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+
+@EntityListeners(AuditingEntityListener.class)
 public class Product {
 }

--- a/src/main/java/com/kakao/borrowme/product/Product.java
+++ b/src/main/java/com/kakao/borrowme/product/Product.java
@@ -1,9 +1,73 @@
 package com.kakao.borrowme.product;
 
+import com.kakao.borrowme.category.Category;
+import com.kakao.borrowme.company.Company;
+import com.kakao.borrowme.location.Location;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.EntityListeners;
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
+@Entity
+@Table(name = "product_tb")
 public class Product {
+    // 추후 String 으로 변경 가능
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_pk")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_pk")
+    private Location location;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "company_pk")
+    private Company company;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_pk")
+    private Category category;
+
+    @NotNull
+    @Column(length = 45)
+    private String name;
+
+    @NotNull
+    private Long rentalPrice;
+
+    @NotNull
+    private Long regularPrice;
+
+    @NotNull
+    private String content;
+
+    @NotNull
+    @CreatedDate
+    private LocalDateTime createAt;
+
+    private LocalDateTime deleteAt;
+
+    @Builder
+    public Product(Long id, Location location, Company company, Category category, String name, Long rentalPrice, Long regularPrice, String content, LocalDateTime createAt, LocalDateTime deleteAt) {
+        this.id = id;
+        this.location = location;
+        this.company = company;
+        this.category = category;
+        this.name = name;
+        this.rentalPrice = rentalPrice;
+        this.regularPrice = regularPrice;
+        this.content = content;
+        this.createAt = createAt;
+        this.deleteAt = deleteAt;
+    }
 }

--- a/src/main/java/com/kakao/borrowme/product/ProductJPARepository.java
+++ b/src/main/java/com/kakao/borrowme/product/ProductJPARepository.java
@@ -1,0 +1,6 @@
+package com.kakao.borrowme.product;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductJPARepository extends JpaRepository<Product, Long> {
+}

--- a/src/main/java/com/kakao/borrowme/product/image/ProductImage.java
+++ b/src/main/java/com/kakao/borrowme/product/image/ProductImage.java
@@ -1,0 +1,4 @@
+package com.kakao.borrowme.product.image;
+
+public class ProductImage {
+}

--- a/src/main/java/com/kakao/borrowme/product/image/ProductImage.java
+++ b/src/main/java/com/kakao/borrowme/product/image/ProductImage.java
@@ -1,4 +1,34 @@
 package com.kakao.borrowme.product.image;
 
+import com.kakao.borrowme.product.Product;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "product_image_tb")
 public class ProductImage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_image_pk")
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_pk")
+    private Product product;
+
+    @Column(length = 200)
+    private String productImagePath;
+
+    @Builder
+    public ProductImage(long id, Product product, String productImagePath) {
+        this.id = id;
+        this.product = product;
+        this.productImagePath = productImagePath;
+    }
 }

--- a/src/main/java/com/kakao/borrowme/product/image/ProductImageJPARepository.java
+++ b/src/main/java/com/kakao/borrowme/product/image/ProductImageJPARepository.java
@@ -1,0 +1,6 @@
+package com.kakao.borrowme.product.image;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductImageJPARepository extends JpaRepository<ProductImage, Long> {
+}

--- a/src/main/java/com/kakao/borrowme/rental/Rental.java
+++ b/src/main/java/com/kakao/borrowme/rental/Rental.java
@@ -1,4 +1,51 @@
 package com.kakao.borrowme.rental;
 
+import com.kakao.borrowme.product.Product;
+import com.kakao.borrowme.user.User;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "rental_tb")
 public class Rental {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "rental_pk")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_pk")
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_pk")
+    private User user;
+
+    @NotNull
+    private LocalDateTime startAt;
+
+    @NotNull
+    private LocalDateTime endAt;
+
+    @NotNull
+    @Column(length = 45)
+    private String status;
+
+    @Builder
+    public Rental(Long id, Product product, User user, LocalDateTime startAt, LocalDateTime endAt, String status) {
+        this.id = id;
+        this.product = product;
+        this.user = user;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.status = status;
+    }
 }

--- a/src/main/java/com/kakao/borrowme/rental/Rental.java
+++ b/src/main/java/com/kakao/borrowme/rental/Rental.java
@@ -1,0 +1,4 @@
+package com.kakao.borrowme.rental;
+
+public class Rental {
+}

--- a/src/main/java/com/kakao/borrowme/rental/RentalJPARepository.java
+++ b/src/main/java/com/kakao/borrowme/rental/RentalJPARepository.java
@@ -1,0 +1,6 @@
+package com.kakao.borrowme.rental;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RentalJPARepository extends JpaRepository<Rental, Long> {
+}

--- a/src/main/java/com/kakao/borrowme/review/Review.java
+++ b/src/main/java/com/kakao/borrowme/review/Review.java
@@ -1,9 +1,64 @@
 package com.kakao.borrowme.review;
 
+import com.kakao.borrowme.product.Product;
+import com.kakao.borrowme.rental.Rental;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.EntityListeners;
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
+@Entity
+@Table(name = "review_tb")
 public class Review {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_pk")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "rental_pk")
+    private Rental rental;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_pk")
+    private Product product;
+
+    @NotNull
+    private int star;
+
+    @NotNull
+    @Column(length = 600)
+    private String content;
+
+    @NotNull
+    @CreatedDate
+    private LocalDateTime createAt;
+
+    @NotNull
+    @LastModifiedDate
+    private LocalDateTime updateAt;
+
+    private LocalDateTime deleteAt;
+
+    @Builder
+    public Review(Long id, Rental rental, Product product, int star, String content, LocalDateTime createAt, LocalDateTime updateAt, LocalDateTime deleteAt) {
+        this.id = id;
+        this.rental = rental;
+        this.product = product;
+        this.star = star;
+        this.content = content;
+        this.createAt = createAt;
+        this.updateAt = updateAt;
+        this.deleteAt = deleteAt;
+    }
 }

--- a/src/main/java/com/kakao/borrowme/review/Review.java
+++ b/src/main/java/com/kakao/borrowme/review/Review.java
@@ -1,0 +1,4 @@
+package com.kakao.borrowme.review;
+
+public class Review {
+}

--- a/src/main/java/com/kakao/borrowme/review/Review.java
+++ b/src/main/java/com/kakao/borrowme/review/Review.java
@@ -1,4 +1,9 @@
 package com.kakao.borrowme.review;
 
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+
+@EntityListeners(AuditingEntityListener.class)
 public class Review {
 }

--- a/src/main/java/com/kakao/borrowme/review/ReviewJPARepository.java
+++ b/src/main/java/com/kakao/borrowme/review/ReviewJPARepository.java
@@ -1,0 +1,6 @@
+package com.kakao.borrowme.review;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewJPARepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/kakao/borrowme/university/University.java
+++ b/src/main/java/com/kakao/borrowme/university/University.java
@@ -1,4 +1,30 @@
 package com.kakao.borrowme.university;
 
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "university_tb")
 public class University {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "university_pk")
+    private Long id;
+
+    @NotNull
+    @Column(length = 45)
+    private String name;
+
+    @Builder
+    public University(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
 }

--- a/src/main/java/com/kakao/borrowme/university/University.java
+++ b/src/main/java/com/kakao/borrowme/university/University.java
@@ -1,0 +1,4 @@
+package com.kakao.borrowme.university;
+
+public class University {
+}

--- a/src/main/java/com/kakao/borrowme/university/UniversityJPARepository.java
+++ b/src/main/java/com/kakao/borrowme/university/UniversityJPARepository.java
@@ -1,0 +1,6 @@
+package com.kakao.borrowme.university;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UniversityJPARepository extends JpaRepository<University, Long> {
+}

--- a/src/main/java/com/kakao/borrowme/user/User.java
+++ b/src/main/java/com/kakao/borrowme/user/User.java
@@ -1,4 +1,9 @@
 package com.kakao.borrowme.user;
 
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+
+@EntityListeners(AuditingEntityListener.class)
 public class User {
 }

--- a/src/main/java/com/kakao/borrowme/user/User.java
+++ b/src/main/java/com/kakao/borrowme/user/User.java
@@ -1,0 +1,4 @@
+package com.kakao.borrowme.user;
+
+public class User {
+}

--- a/src/main/java/com/kakao/borrowme/user/User.java
+++ b/src/main/java/com/kakao/borrowme/user/User.java
@@ -1,9 +1,77 @@
 package com.kakao.borrowme.user;
 
+import com.kakao.borrowme.university.University;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import javax.persistence.EntityListeners;
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDateTime;
 
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
+@Entity
+@Table(name = "user_tb")
 public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_pk")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "university_pk")
+    private University university;
+
+    @NotNull
+    @Column(length = 45)
+    private String email;
+
+    // 해시 알고리즘 저장 필요
+    @NotNull
+    private String password;
+
+    @NotNull
+    @Column(length = 45)
+    private String nickname;
+
+    @NotNull
+    @Column(length = 45)
+    private String role;
+
+    @Column(length = 200)
+    private String idCardImagePath;
+
+    @Column(length = 200)
+    private String profileImagePath;
+
+    @NotNull
+    @CreatedDate
+    private LocalDateTime createAt;
+
+    @NotNull
+    @LastModifiedDate
+    private LocalDateTime updateAt;
+
+    private LocalDateTime deleteAt;
+
+    @Builder
+    public User(Long id, University university, String email, String password, String nickname, String role, String idCardImagePath, String profileImagePath, LocalDateTime createAt, LocalDateTime updateAt, LocalDateTime deleteAt) {
+        this.id = id;
+        this.university = university;
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.role = role;
+        this.idCardImagePath = idCardImagePath;
+        this.profileImagePath = profileImagePath;
+        this.createAt = createAt;
+        this.updateAt = updateAt;
+        this.deleteAt = deleteAt;
+    }
 }

--- a/src/main/java/com/kakao/borrowme/user/UserJPARepository.java
+++ b/src/main/java/com/kakao/borrowme/user/UserJPARepository.java
@@ -1,0 +1,6 @@
+package com.kakao.borrowme.user;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJPARepository extends JpaRepository<User, Long> {
+}


### PR DESCRIPTION
## 요약
엔티티 및 레포지토리 생성하였습니다.

## 관련 이슈
#6 #17

## 작업 내용
ERD 약간 변경하였습니다.
- User-Coin 의 관계를 일대다 관계 에서 일대일 관계 로 변경
- Company 객체의 이름을 company_img_path 에서 company_image_path 로 변경
- User 객체의 password 타입을 varchar(300) 에서 text 로 변경
- decimal 소수점 명시
- Product 객체의 rental_price, regular_price 타입을 varchar(200) 에서 bigint(11) 로 변경

## 기타
우선 Product의 PK를 Long 타입으로 선언하였습니다. 추후 String으로 변경할 수 있습니다.
Password를 DB에 그대로 저장하는 것 보다 추후 해시 알고리즘을 사용하는 것이 좋을 것 같습니다.
imagePath에 Default를 걸어줄 지, 아니면 null도 허용 가능하게 해야할 지 모르겠습니다.
LocalDateTime vs Instant 문제에서 우선 LocalDateTime 을 채택하였습니다.