### PR TITLE
[BE-13] Spring Security 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation group: 'com.auth0', name: 'java-jwt', version: '4.4.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
 //    runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/kakao/borrowme/_core/security/JWTProvider.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/JWTProvider.java
@@ -1,0 +1,35 @@
+package com.kakao.borrowme._core.security;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.kakao.borrowme.user.User;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+public class JWTProvider {
+    public static final Long ACCESS_EXP = 1000L * 60 * 60 * 48;
+    public static final String TOKEN_PREFIX = "Bearer ";
+    public static final String HEADER = "Authorization";
+    public static final String SECRET = "MySecretKey";
+
+    public static String create(User user) {
+        String jwt = JWT.create()
+                .withSubject("AccessToken")
+                .withExpiresAt(new Date(System.currentTimeMillis() + ACCESS_EXP))
+                .withClaim("id", user.getId())
+                .withClaim("nickname", user.getNickname())
+                .sign(Algorithm.HMAC512(SECRET));
+        return TOKEN_PREFIX + jwt;
+    }
+
+    public static DecodedJWT verify(String jwt) throws SignatureVerificationException, TokenExpiredException {
+        DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC512(SECRET))
+                .build().verify(jwt.replace(JWTProvider.TOKEN_PREFIX, ""));
+        return decodedJWT;
+    }
+}

--- a/src/main/java/com/kakao/borrowme/_core/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/JwtAuthenticationFilter.java
@@ -1,6 +1,14 @@
 package com.kakao.borrowme._core.security;
 
+import com.auth0.jwt.exceptions.SignatureVerificationException;
+import com.auth0.jwt.exceptions.TokenExpiredException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.kakao.borrowme.user.User;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
 
 import javax.servlet.FilterChain;
@@ -9,6 +17,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+@Slf4j
 public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
     public JwtAuthenticationFilter(AuthenticationManager authenticationManager) {
         super(authenticationManager);
@@ -19,6 +28,26 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
         String jwt = request.getHeader(JWTProvider.HEADER);
 
         if (jwt == null) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            DecodedJWT decodedJWT = JWTProvider.verify(jwt);
+            Long id = decodedJWT.getClaim("id").asLong();
+            String nickname = decodedJWT.getClaim("role").asString();
+            User user = User.builder().id(id).nickname(nickname).build();
+
+            CustomUserDetails myUserDetails = new CustomUserDetails(user);
+            Authentication authentication = new UsernamePasswordAuthenticationToken(
+                    myUserDetails, myUserDetails.getPassword(), myUserDetails.getAuthorities());
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug("디버그: 인증 객체 만들어짐");
+        } catch (SignatureVerificationException sve) {
+            log.error("토큰 검증 실패");
+        } catch (TokenExpiredException tee) {
+            log.error("토큰 만료됨");
+        } finally {
             chain.doFilter(request, response);
         }
     }

--- a/src/main/java/com/kakao/borrowme/_core/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/JwtAuthenticationFilter.java
@@ -1,0 +1,25 @@
+package com.kakao.borrowme._core.security;
+
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.web.authentication.www.BasicAuthenticationFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
+    public JwtAuthenticationFilter(AuthenticationManager authenticationManager) {
+        super(authenticationManager);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+        String jwt = request.getHeader(JWTProvider.HEADER);
+
+        if (jwt == null) {
+            chain.doFilter(request, response);
+        }
+    }
+}

--- a/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
@@ -50,6 +50,11 @@ public class SecurityConfig {
             log.error("인증되지 않았습니다");
         });
 
+        // 9. 권한 실패 처리
+        http.exceptionHandling().accessDeniedHandler((request, response, accessDeniedException) -> {
+            log.error("권한이 없습니다");
+        });
+
         return http.build();
     }
 

--- a/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
@@ -16,6 +16,9 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        // 1. CSRF 해제
+        http.csrf().disable();
+
         return http.build();
     }
 }

--- a/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.kakao.borrowme._core.security;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -21,6 +22,9 @@ public class SecurityConfig {
 
         // 2. Cross-Origin 사용 거부
         http.headers().frameOptions().sameOrigin();
+
+        // 3. jSessionID 사용 거부
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
         return http.build();
     }

--- a/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
@@ -2,7 +2,9 @@ package com.kakao.borrowme._core.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -32,6 +34,18 @@ public class SecurityConfig {
         // 5. HttpBasicAuthenticationFilter 해제
         http.httpBasic().disable();
 
+        // 6. CustomSecurityFilter 적용
+        http.apply(new CustomSecurityFilterManager());
+
         return http.build();
+    }
+
+    public class CustomSecurityFilterManager extends AbstractHttpConfigurer<CustomSecurityFilterManager, HttpSecurity> {
+        @Override
+        public void configure(HttpSecurity http) throws Exception {
+            AuthenticationManager authenticationManager = http.getSharedObject(AuthenticationManager.class);
+            http.addFilter(new JwtAuthenticationFilter(authenticationManager));
+            super.configure(http);
+        }
     }
 }

--- a/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
@@ -29,6 +29,9 @@ public class SecurityConfig {
         // 4. UsernamePasswordAuthenticationFilter 해제
         http.formLogin().disable();
 
+        // 5. HttpBasicAuthenticationFilter 해제
+        http.httpBasic().disable();
+
         return http.build();
     }
 }

--- a/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
@@ -26,6 +26,9 @@ public class SecurityConfig {
         // 3. jSessionID 사용 거부
         http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
+        // 4. UsernamePasswordAuthenticationFilter 해제
+        http.formLogin().disable();
+
         return http.build();
     }
 }

--- a/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
@@ -19,6 +19,9 @@ public class SecurityConfig {
         // 1. CSRF 해제
         http.csrf().disable();
 
+        // 2. Cross-Origin 사용 거부
+        http.headers().frameOptions().sameOrigin();
+
         return http.build();
     }
 }

--- a/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.kakao.borrowme._core.security;
 
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -13,6 +14,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+@Slf4j
 @Configuration
 public class SecurityConfig {
     @Bean
@@ -42,6 +44,11 @@ public class SecurityConfig {
 
         // 7. CORS 재설정
         http.cors().configurationSource(configurationSource());
+
+        // 8. 인증 실패 처리
+        http.exceptionHandling().authenticationEntryPoint((request, response, authException) -> {
+            log.error("인증되지 않았습니다");
+        });
 
         return http.build();
     }

--- a/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
@@ -9,6 +9,9 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @Configuration
 public class SecurityConfig {
@@ -37,6 +40,9 @@ public class SecurityConfig {
         // 6. CustomSecurityFilter 적용
         http.apply(new CustomSecurityFilterManager());
 
+        // 7. CORS 재설정
+        http.cors().configurationSource(configurationSource());
+
         return http.build();
     }
 
@@ -47,5 +53,17 @@ public class SecurityConfig {
             http.addFilter(new JwtAuthenticationFilter(authenticationManager));
             super.configure(http);
         }
+    }
+
+    public CorsConfigurationSource configurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedHeader("*");
+        configuration.addAllowedMethod("*"); // GET, POST, PUT, DELETE (Javascript 요청 허용)
+        configuration.addAllowedOriginPattern("*"); // 모든 IP 주소 허용 -> 프론트 IP 접근 한정 필요
+        configuration.setAllowCredentials(true); // 클라이언트 쿠키 요청 허용
+        configuration.addExposedHeader("Authorization");
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
@@ -55,6 +55,12 @@ public class SecurityConfig {
             log.error("권한이 없습니다");
         });
 
+        // 10. 인증, 권한 필터 설정
+        http.authorizeRequests(
+                authorize -> authorize.antMatchers("/user/join/**", "/user/login/**", "/h2-console/**").permitAll()
+                        .anyRequest().authenticated()
+        );
+
         return http.build();
     }
 

--- a/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
+++ b/src/main/java/com/kakao/borrowme/_core/security/SecurityConfig.java
@@ -16,15 +16,6 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        // 1. CSRF 해제
-        http.csrf().disable();
-
-        // 2. UsernamePasswordAuthenticationFilter 해제
-        http.formLogin().disable();
-
-        // 3. HttpBasicAuthenticationFilter 해제
-        http.httpBasic().disable();
-
         return http.build();
     }
 }


### PR DESCRIPTION
## 요약
Spring Security 기본적인 보안 정책 설정하였습니다.

## 관련 이슈
#26

## 작업 내용
1. CSRF 해제
2. Cross-Origin 사용 거부
3. jSessionID 사용 거부
4. UsernamePasswordAuthenticationFilter 해제
5. HttpBasicAuthenticationFilter 해제
6. CustomSecurityFilter 적용
7. CORS 재설정
8. 인증 실패 처리
9. 권한 실패 처리
10. 인증, 권한 필터 설정

## 기타
H2 Console 접속 가능하며, 데이터베이스 연결도 확인하였습니다.
인증 객체 생성은 아직 미구현 상태입니다.
예상되는 이슈로는 https://solitas0817.tistory.com/4 가 있습니다.